### PR TITLE
CMAKE: Bump minimum version to 3.25.0.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,12 +15,6 @@ else()
     set(FMEM_LIBRARY_TYPE SHARED)
 endif()
 
-if (POLICY CMP0048)
-  # cmake warns if fmem is included from a parent directory whose CMakeLists.txt
-  # requires a CMake version of 3.0 or later
-  cmake_policy(SET CMP0048 NEW)
-endif()
-
 project (fmem C)
 list (APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/.cmake")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Redistribution and use of this file is allowed according to the terms of the MIT license.
 # For details see the LICENSE file distributed with Mimick.
 
-cmake_minimum_required (VERSION 2.8.12)
+cmake_minimum_required (VERSION 3.22.0)
 
 option(BUILD_SHARED_LIBS "Build shared library." OFF)
 # Add an option to control whether to build static or shared library
@@ -146,7 +146,7 @@ install(TARGETS fmem
 install(FILES
    ${PROJECT_BINARY_DIR}/gen/fmem.h
    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
-   
+
 # Check if this is the main project and BUILD_TESTING was not already set by the user
 if("${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}" AND NOT DEFINED BUILD_TESTING)
     message(WARNING "Detected that we're only compiling this project. BUILD_TESTING was not explicitly set, defaulting to BUILD_TESTING=ON. To disable testing, set BUILD_TESTING=OFF.")
@@ -158,12 +158,12 @@ if (WIN32)
 else()
     set(LIB_EXT ".a")
 endif()
-  
+
 if ("${CMAKE_SOURCE_DIR}" STREQUAL "${PROJECT_SOURCE_DIR}" AND BUILD_TESTING)
     find_package(Criterion QUIET)
     if (NOT CRITERION_FOUND)
         find_program(MESON_FOUND meson)
-          
+
   if(NOT MESON_FOUND)
   message(STATUS "Meson not found. Attempting to call meson --version for debugging.")
   execute_process(
@@ -188,7 +188,7 @@ endif()
 
             # Set include directories and library paths
             set(CRITERION_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/Criterion/include")
-            set(CRITERION_LIBRARIES "${CMAKE_BINARY_DIR}/Criterion/src/libcriterion${LIB_EXT}")        
+            set(CRITERION_LIBRARIES "${CMAKE_BINARY_DIR}/Criterion/src/libcriterion${LIB_EXT}")
 
             # Check if criterion.h exists in the provided include directory
             if(EXISTS "${CRITERION_INCLUDE_DIRS}/criterion/criterion.h")


### PR DESCRIPTION
Newer versions of cmake dropped support for CMAKE_MINIMUM_REQUIRED < 3.5, hence I bumped the minimum version.

## Summary by Sourcery

Update CMakeLists.txt to require CMake 3.25.0 or newer and clean up trailing whitespace.

Enhancements:
- Bump minimum required CMake version from 2.8.12 to 3.25.0.

Chores:
- Remove various trailing whitespace from CMakeLists.txt.